### PR TITLE
Api token support

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/sonar/HubPropertyConstants.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/sonar/HubPropertyConstants.java
@@ -40,6 +40,7 @@ public class HubPropertyConstants {
     public static final String HUB_URL = HUB_SONAR_PREFIX + "url";
     public static final String HUB_USERNAME = HUB_SONAR_PREFIX + "username";
     public static final String HUB_PASSWORD = HUB_SONAR_PREFIX + "password";
+    public static final String HUB_API_TOKEN = HUB_SONAR_PREFIX + "token";
     public static final String HUB_TIMEOUT = HUB_SONAR_PREFIX + "timeout";
     public static final String HUB_TRUST_SSL_CERT = HUB_SONAR_PREFIX + "trust.ssl.cert";
 

--- a/src/main/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManager.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManager.java
@@ -58,6 +58,7 @@ public class SonarManager {
             configBuilder.setUrl(getValue(HubPropertyConstants.HUB_URL));
             configBuilder.setUsername(getValue(HubPropertyConstants.HUB_USERNAME));
             configBuilder.setPassword(getValue(HubPropertyConstants.HUB_PASSWORD));
+            configBuilder.setApiToken(getValue(HubPropertyConstants.HUB_SONAR_PREFIX + ".token"));
             configBuilder.setTimeoutInSeconds(getValue(HubPropertyConstants.HUB_TIMEOUT));
             configBuilder.setTrustCert(Boolean.parseBoolean(getValue(HubPropertyConstants.HUB_TRUST_SSL_CERT)));
 

--- a/src/main/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManager.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManager.java
@@ -58,7 +58,7 @@ public class SonarManager {
             configBuilder.setUrl(getValue(HubPropertyConstants.HUB_URL));
             configBuilder.setUsername(getValue(HubPropertyConstants.HUB_USERNAME));
             configBuilder.setPassword(getValue(HubPropertyConstants.HUB_PASSWORD));
-            configBuilder.setApiToken(getValue(HubPropertyConstants.HUB_SONAR_PREFIX + ".token"));
+            configBuilder.setApiToken(getValue(HubPropertyConstants.HUB_API_TOKEN));
             configBuilder.setTimeoutInSeconds(getValue(HubPropertyConstants.HUB_TIMEOUT));
             configBuilder.setTrustCert(Boolean.parseBoolean(getValue(HubPropertyConstants.HUB_TRUST_SSL_CERT)));
 

--- a/src/test/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManagerTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManagerTest.java
@@ -23,12 +23,16 @@
  */
 package com.blackducksoftware.integration.hub.sonar.manager;
 
+import static com.blackducksoftware.integration.hub.sonar.HubPropertyConstants.HUB_URL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Optional;
 
+import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -45,6 +49,7 @@ public class SonarManagerTest {
     private static final String DELIMITER = ", ";
 
     private static final String EXAMPLE_KEY = "key";
+    public static final String HUB_TOKEN = HubPropertyConstants.HUB_SONAR_PREFIX + ".token";
 
     private File baseDir;
     private SensorContext sensorContext;
@@ -118,8 +123,7 @@ public class SonarManagerTest {
     @Test
     public void getHubPluginVersionTest() {
         SonarManager manager = new SonarManager(sensorContext);
-
-        assertTrue("<unknown>" != manager.getHubPluginVersionFromFile("/plugin.properties"));
+        assertNotEquals("<unknown>", manager.getHubPluginVersionFromFile("/plugin.properties"));
     }
 
     @Test
@@ -127,5 +131,19 @@ public class SonarManagerTest {
         SonarManager manager = new SonarManager(sensorContext);
 
         assertEquals("<unknown>", manager.getHubPluginVersionFromFile("/NULL"));
+    }
+
+    @Test
+    public void getBlackDuckServerConfigFromSettingsTest() {
+        MapSettings settings = new MapSettings();
+        settings.setProperty(HUB_URL, "http://127.0.0.1/valid/url");
+        settings.setProperty(HUB_TOKEN, HUB_TOKEN + ".testValue");
+
+        sensorContext = new MockSensorContext(settings.asConfig(), new MockFileSystem(baseDir));
+        SonarManager manager = new SonarManager(sensorContext);
+
+        Optional<BlackDuckServerConfig> blackDuckServerConfig = manager.getBlackDuckServerConfigFromSettings();
+        assertTrue(blackDuckServerConfig.isPresent());
+        assertEquals(settings.asConfig().get(HUB_TOKEN), blackDuckServerConfig.get().getApiToken());
     }
 }

--- a/src/test/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManagerTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/sonar/manager/SonarManagerTest.java
@@ -23,6 +23,7 @@
  */
 package com.blackducksoftware.integration.hub.sonar.manager;
 
+import static com.blackducksoftware.integration.hub.sonar.HubPropertyConstants.HUB_API_TOKEN;
 import static com.blackducksoftware.integration.hub.sonar.HubPropertyConstants.HUB_URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -49,7 +50,6 @@ public class SonarManagerTest {
     private static final String DELIMITER = ", ";
 
     private static final String EXAMPLE_KEY = "key";
-    public static final String HUB_TOKEN = HubPropertyConstants.HUB_SONAR_PREFIX + ".token";
 
     private File baseDir;
     private SensorContext sensorContext;
@@ -137,13 +137,13 @@ public class SonarManagerTest {
     public void getBlackDuckServerConfigFromSettingsTest() {
         MapSettings settings = new MapSettings();
         settings.setProperty(HUB_URL, "http://127.0.0.1/valid/url");
-        settings.setProperty(HUB_TOKEN, HUB_TOKEN + ".testValue");
+        settings.setProperty(HUB_API_TOKEN, HUB_API_TOKEN + ".testValue");
 
         sensorContext = new MockSensorContext(settings.asConfig(), new MockFileSystem(baseDir));
         SonarManager manager = new SonarManager(sensorContext);
 
         Optional<BlackDuckServerConfig> blackDuckServerConfig = manager.getBlackDuckServerConfigFromSettings();
         assertTrue(blackDuckServerConfig.isPresent());
-        assertEquals(settings.asConfig().get(HUB_TOKEN), blackDuckServerConfig.get().getApiToken());
+        assertEquals(settings.asConfig().get(HUB_API_TOKEN), blackDuckServerConfig.get().getApiToken());
     }
 }


### PR DESCRIPTION
Hi guys,

it seems support for API Token was implemented ages ago, but somehow forgotten to be added to SonarManager. As token support is essential in our case and also requested by this [issue](https://github.com/blackducksoftware/hub-sonarqube/issues/8) here, I decided to add a quick change for that. 

Initial plan was to upgrade to most recent blackduck-common version (47.0.1 -> 58.0.2) and update sonarqube-plugin-api as well, but due to lack of documentation and tons of breaking API changes in blackduck-common, I just added property handling for api token configuration to SonarManager.